### PR TITLE
fetch is not a function

### DIFF
--- a/components/SearchResults.js
+++ b/components/SearchResults.js
@@ -11,7 +11,7 @@ var {
 	View,
 } = React;
 
-var fetch = require('fetch');
+var fetch = require('fetch').fetch;
 
 var HouseCell = require('./HouseCell.js');
 var HouseDetails = require('./HouseDetails.js');

--- a/components/SearchResults.js
+++ b/components/SearchResults.js
@@ -11,8 +11,6 @@ var {
 	View,
 } = React;
 
-var fetch = require('fetch').fetch;
-
 var HouseCell = require('./HouseCell.js');
 var HouseDetails = require('./HouseDetails.js');
 var SearchNoResults = require('./SearchNoResults.js');


### PR DESCRIPTION
I was getting `fetch is not a function` from `SearchResults.js:171`

Fetch is a method of var fetch = require('fetch');
console.log(fetch)
`=> Object {Headers: function, Request: function, Response: function, fetch: function}`

fetch.js
`module.exports = self;` and self has a method named fetch
`self.fetch = function(input, init)...`

Everything worked after I made this change.
